### PR TITLE
Default to a 1 status code on errors

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -28,6 +28,6 @@ module.exports = function spawn (referrer, opts = {}) {
   try {
     require('child_process').execFileSync(bin, process.argv.slice(2), { stdio: 'inherit' })
   } catch (err) {
-    process.exitCode = err.status
+    process.exitCode = err.status || 1
   }
 }


### PR DESCRIPTION
Currently an error can result in a 0 status-code (when `err.status` is `null`), which I don't think is expected.

Could also be 
```
process.exitCode = err.status === 0
  ? 0
  :  err.status || 1
  ```

If an error should be able to specify it's still a successful execution, but not sure if that makes sense