### PR TITLE
fix: support pnpm runtime resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,21 +14,43 @@ module.exports = function runtime(referrer, opts) {
   const { platform = os.platform(), arch = os.arch() } = opts
 
   const filename = path.basename(referrer)
+  const pkg = `bare-runtime-${platform}-${arch}`
 
-  let mod
+  let pkgDir
   try {
-    mod = require(`bare-runtime-${platform}-${arch}`)
+    pkgDir = path.dirname(require.resolve(`${pkg}/package`))
   } catch (err) {
-    if (err.code === 'MODULE_NOT_FOUND') {
+    if (isModuleNotFound(err, `${pkg}/package`)) {
       throw new Error(`No binaries found for target '${platform}-${arch}'`)
     } else {
       throw err
     }
   }
 
+  const bin = resolvePackageBin(pkgDir, filename)
+
+  if (bin !== null) return bin
+
+  const mod = require(pkgDir)
+
   if (filename in mod === false) {
     throw new Error(`No binary found for target '${platform}-${arch}' for referrer '${referrer}'`)
   }
 
   return mod[filename]
+}
+
+function isModuleNotFound(err, request) {
+  return (
+    err &&
+    err.code === 'MODULE_NOT_FOUND' &&
+    err.message.startsWith(`Cannot find module '${request}'`)
+  )
+}
+
+function resolvePackageBin(pkgDir, filename) {
+  const pkg = require(path.join(pkgDir, 'package.json'))
+  const bin = pkg.bin && pkg.bin[filename]
+
+  return typeof bin === 'string' ? path.join(pkgDir, bin) : null
 }


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- pnpm can install the current-platform optional runtime package without making it resolvable from `bare-runtime`'s package location.
- Node consumers can fail with `No binaries found for target ...` even though the matching runtime binary package is present.

## 📝 How does it solve it?

- Resolve the selected platform package's package metadata first, then return the matching binary path from its `bin` map.
- Keep the existing module fallback for non-bin referrers and keep missing-platform errors scoped to the platform package resolution failure.

## 🧪 How was it tested?

- `node --check index.js`
- Shell-only pnpm reproduction with strict hoisting disabled:

```sh
tmp="$(mktemp -d)"
cd "$tmp"
printf 'hoist=false\npublic-hoist-pattern[]=\n' > .npmrc
pnpm init
pnpm add bare-runtime@1.28.5
node - <<'NODE'
const fs = require('fs')
const runtime = require('bare-runtime')

const bin = runtime('bare')
console.log(bin)

if (!fs.existsSync(bin)) {
  throw new Error(`resolved binary does not exist: ${bin}`)
}
NODE
```

- Before this change, the shell-only reproduction fails with `Error: No binaries found for target 'darwin-arm64'`.
- With a locally packed version of this branch installed in the same shell-only pnpm scenario, it resolves the platform binary path successfully.
- Packed `bare-runtime` locally and installed it with pnpm in a QVAC SDK/CLI test project.
- Ran `pnpm exec qvac serve openai --cors`; Bare started and QVAC reached `QVAC API server listening`.
- Verified a missing target still reports `No binaries found for target 'notreal-x64'`.