### PR TITLE
Upgrade bare-subprocess to ^6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "bare-os": "^3.0.1",
     "bare-path": "^3.0.0",
     "bare-process": "^4.2.1",
-    "bare-subprocess": "^5.0.0"
+    "bare-subprocess": "^6.1.0"
   },
   "optionalDependencies": {
     "bare-runtime-android-arm": "1.28.6",


### PR DESCRIPTION
v6 aligns the `exit`/`close` events to Node.js, emitting signal *names* (`'SIGTERM'`) instead of numbers. `lib/spawn.js` indexes `os.constants.signals` by name in its `forwardExitCode` path, so v6 corrects signal-to-exit-code forwarding on Bare; the `suppressSignals` path is unaffected. The surface we use is just `spawn` + the `exit` event.

Follow-up: add a brittle-bare test covering `spawn()`'s exit/signal forwarding (separate PR — needs test infra this repo doesn't have yet).