### PR TITLE
1.28.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(cmake-fetch REQUIRED PATHS node_modules/cmake-fetch)
 
 project(bare_runtime C)
 
-fetch_package("github:holepunchto/bare@1.28.6")
+fetch_package("github:holepunchto/bare@1.28.7")
 
 add_custom_target(bare_runtime ALL DEPENDS bare_bin bare_shared)
 

--- a/npm/android-arm/package.json
+++ b/npm/android-arm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-android-arm",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The Android ARM 32-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/android-arm64/package.json
+++ b/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-android-arm64",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The Android ARM 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/android-ia32/package.json
+++ b/npm/android-ia32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-android-ia32",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The Android Intel 32-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/android-x64/package.json
+++ b/npm/android-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-android-x64",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The Android Intel 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-darwin-arm64",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The macOS ARM 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-darwin-x64",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The macOS Intel 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/ios-arm64-simulator/package.json
+++ b/npm/ios-arm64-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-ios-arm64-simulator",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The iOS ARM simulator 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/ios-arm64/package.json
+++ b/npm/ios-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-ios-arm64",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The iOS ARM 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/ios-x64-simulator/package.json
+++ b/npm/ios-x64-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-ios-x64-simulator",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The iOS Intel simulator 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-linux-arm64",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The Linux ARM 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-linux-x64",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The Linux Intel 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/win32-arm64/package.json
+++ b/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-win32-arm64",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The Windows ARM 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime-win32-x64",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "The Windows Intel 64-bit binary for Bare",
   "exports": {
     ".": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-runtime",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "Prebuilt Bare binaries for macOS, iOS, Linux, Android, and Windows",
   "exports": {
     ".": "./index.js",
@@ -63,19 +63,19 @@
     "bare-subprocess": "^6.1.0"
   },
   "optionalDependencies": {
-    "bare-runtime-android-arm": "1.28.6",
-    "bare-runtime-android-arm64": "1.28.6",
-    "bare-runtime-android-ia32": "1.28.6",
-    "bare-runtime-android-x64": "1.28.6",
-    "bare-runtime-darwin-arm64": "1.28.6",
-    "bare-runtime-darwin-x64": "1.28.6",
-    "bare-runtime-ios-arm64": "1.28.6",
-    "bare-runtime-ios-arm64-simulator": "1.28.6",
-    "bare-runtime-ios-x64-simulator": "1.28.6",
-    "bare-runtime-linux-arm64": "1.28.6",
-    "bare-runtime-linux-x64": "1.28.6",
-    "bare-runtime-win32-arm64": "1.28.6",
-    "bare-runtime-win32-x64": "1.28.6"
+    "bare-runtime-android-arm": "1.28.7",
+    "bare-runtime-android-arm64": "1.28.7",
+    "bare-runtime-android-ia32": "1.28.7",
+    "bare-runtime-android-x64": "1.28.7",
+    "bare-runtime-darwin-arm64": "1.28.7",
+    "bare-runtime-darwin-x64": "1.28.7",
+    "bare-runtime-ios-arm64": "1.28.7",
+    "bare-runtime-ios-arm64-simulator": "1.28.7",
+    "bare-runtime-ios-x64-simulator": "1.28.7",
+    "bare-runtime-linux-arm64": "1.28.7",
+    "bare-runtime-linux-x64": "1.28.7",
+    "bare-runtime-win32-arm64": "1.28.7",
+    "bare-runtime-win32-x64": "1.28.7"
   },
   "devDependencies": {
     "cmake-bare": "^1.7.7",


### PR DESCRIPTION
Track Bare v1.28.7. Includes the bare-subprocess ^6.1.0 bump from #8.